### PR TITLE
  fix: Add --include-empty-classes flag to control empty class inclusion

### DIFF
--- a/gitex/docstring_extractor.py
+++ b/gitex/docstring_extractor.py
@@ -2,7 +2,7 @@ import ast
 from pathlib import Path
 from typing import Optional, List
 
-def extract_docstrings(file_path: Path, symbol_path: Optional[str] = None) -> str:
+def extract_docstrings(file_path: Path, symbol_path: Optional[str] = None, include_empty_classes: bool = False) -> str:
     """
     Extracts module, class, and function docstrings and signatures from a Python file,
     preserving the code structure. If a symbol_path is provided, it extracts
@@ -56,6 +56,10 @@ def extract_docstrings(file_path: Path, symbol_path: Optional[str] = None) -> st
             docstring = ast.get_docstring(node)
             if docstring:
                 output.append(f'{indent}    """{docstring}"""')
+            elif not include_empty_classes:
+                # Remove the signature we just added if no docstring and not including empty classes
+                output.pop()
+                return
 
             # If it's a class, process its body
             if isinstance(node, ast.ClassDef):

--- a/gitex/main.py
+++ b/gitex/main.py
@@ -37,7 +37,9 @@ def _filter_nodes(nodes):
 @click.option("--extract-docstrings", "extract_symbol",
               help="Extract docstrings for a specific symbol (e.g., gitex.renderer.Renderer) or all files if no symbol is provided.",
               metavar="SYMBOL_PATH", default=None, is_flag=False, flag_value="*")
-def cli(path, interactive, no_files, base_dir, extract_symbol):
+@click.option("--include-empty-classes", is_flag=True,
+              help="Include classes and functions without docstrings when using --extract-docstrings.")
+def cli(path, interactive, no_files, base_dir, extract_symbol, include_empty_classes):
     """
     Renders a repository's file tree and optional file contents for LLM prompts.
 
@@ -65,7 +67,7 @@ def cli(path, interactive, no_files, base_dir, extract_symbol):
         if extract_symbol:
             click.echo("\n\n### Extracted Docstrings and Signatures ###\n")
             symbol_target = None if extract_symbol == "*" else extract_symbol
-            click.echo(renderer.render_docstrings(base_dir or str(root), symbol_target))
+            click.echo(renderer.render_docstrings(base_dir or str(root), symbol_target, include_empty_classes))
         else:
             click.echo("\n\n### File Contents ###\n")
             click.echo(renderer.render_files(base_dir or str(root)))

--- a/gitex/renderer.py
+++ b/gitex/renderer.py
@@ -54,7 +54,7 @@ class Renderer:
 
         return "\n\n".join(blocks)
 
-    def render_docstrings(self, base_dir: Optional[str] = None, symbol_target: Optional[str] = None) -> str:
+    def render_docstrings(self, base_dir: Optional[str] = None, symbol_target: Optional[str] = None, include_empty_classes: bool = False) -> str:
         """Return all file contents, each block prefixed by its full or relative path."""
         file_nodes = self._collect_files(self.nodes)
         blocks = []
@@ -75,7 +75,7 @@ class Renderer:
             
             if target_file_path:
                 path_display = self._relative_path(target_file_path, base_dir)
-                content = extract_docstrings(Path(target_file_path), symbol_target)
+                content = extract_docstrings(Path(target_file_path), symbol_target, include_empty_classes)
                 blocks.append(f"# {path_display}\n{content}")
             else:
                 return f"Error: Could not find a Python file corresponding to the symbol '{symbol_target}'."
@@ -86,7 +86,7 @@ class Renderer:
                 if not node.name.endswith(".py"):
                     continue
                 path_display = self._relative_path(node.path, base_dir)
-                content = extract_docstrings(Path(node.path))
+                content = extract_docstrings(Path(node.path), None, include_empty_classes)
                 blocks.append(f"# {path_display}\n{content}")
 
         return "\n\n".join(blocks)


### PR DESCRIPTION
  ## Summary
  - Fixes issue where `--extract-docstrings` was including empty classes and functions without docstrings
  - Adds new `--include-empty-classes` flag to give users control over this behavior
  - By default, classes/functions without docstrings are now filtered out (fixing the reported issue)
  - When `--include-empty-classes` is used, the old behavior is preserved

  ## Test plan
  - [x] Test `--extract-docstrings` without flag - empty classes are filtered out
  - [x] Test `--extract-docstrings --include-empty-classes` - empty classes are included
  - [x] Verify backward compatibility when flag is used
  - [x] Test with both specific symbols and all-files extraction


  ## Related Issue
  Fixes #15 
